### PR TITLE
BufferedInputStream in PrincetonObjectDictionaryFile

### DIFF
--- a/extjwnl/src/main/java/net/sf/extjwnl/princeton/file/PrincetonObjectDictionaryFile.java
+++ b/extjwnl/src/main/java/net/sf/extjwnl/princeton/file/PrincetonObjectDictionaryFile.java
@@ -150,7 +150,7 @@ public class PrincetonObjectDictionaryFile extends AbstractPrincetonDictionaryFi
     private void openInputStream() throws JWNLException {
         try {
             fin = new FileInputStream(getFile());
-            in = new ObjectInputStream(fin);
+            in = new ObjectInputStream(new BufferedInputStream(fin, 8192));
         } catch (IOException e) {
             throw new JWNLIOException(e);
         }


### PR DESCRIPTION
fixes #10, should make loading MapBackedDictionary faster.