### PR TITLE
getRandomIndexWord using a explicit random

### DIFF
--- a/extjwnl/src/main/java/net/sf/extjwnl/dictionary/DatabaseBackedDictionary.java
+++ b/extjwnl/src/main/java/net/sf/extjwnl/dictionary/DatabaseBackedDictionary.java
@@ -13,6 +13,7 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.Iterator;
 import java.util.NoSuchElementException;
+import java.util.Random;
 
 /**
  * Database-backed dictionary.
@@ -307,4 +308,9 @@ public class DatabaseBackedDictionary extends AbstractCachingDictionary {
             return getException(getPOS(), derivation);
         }
     }
+
+	@Override
+	public IndexWord getRandomIndexWord(POS pos, Random random) throws JWNLException {
+		return getRandomIndexWord(pos);
+	}
 }

--- a/extjwnl/src/main/java/net/sf/extjwnl/dictionary/DatabaseBackedDictionary.java
+++ b/extjwnl/src/main/java/net/sf/extjwnl/dictionary/DatabaseBackedDictionary.java
@@ -309,8 +309,4 @@ public class DatabaseBackedDictionary extends AbstractCachingDictionary {
         }
     }
 
-	@Override
-	public IndexWord getRandomIndexWord(POS pos, Random random) throws JWNLException {
-		return getRandomIndexWord(pos);
-	}
 }

--- a/extjwnl/src/main/java/net/sf/extjwnl/dictionary/Dictionary.java
+++ b/extjwnl/src/main/java/net/sf/extjwnl/dictionary/Dictionary.java
@@ -34,6 +34,19 @@ import java.util.*;
 public abstract class Dictionary {
 
     private static final Logger log = LoggerFactory.getLogger(Dictionary.class);
+    
+    private Random rand = null;
+
+    public Random getRandom() {
+    	if(rand==null) {
+    		rand=new Random(new Date().getTime());
+    	}
+		return rand;
+	}
+
+	public void setRandom(Random rand) {
+		this.rand = rand;
+	}
 
     // messages for static methods
     private static final String STATIC_MESSAGES = "net.sf.extjwnl.dictionary.messages_static";
@@ -990,6 +1003,4 @@ public abstract class Dictionary {
             }
         }
     }
-
-    public abstract IndexWord getRandomIndexWord(POS pos, Random random) throws JWNLException;
 }

--- a/extjwnl/src/main/java/net/sf/extjwnl/dictionary/Dictionary.java
+++ b/extjwnl/src/main/java/net/sf/extjwnl/dictionary/Dictionary.java
@@ -990,4 +990,6 @@ public abstract class Dictionary {
             }
         }
     }
+
+    public abstract IndexWord getRandomIndexWord(POS pos, Random random) throws JWNLException;
 }

--- a/extjwnl/src/main/java/net/sf/extjwnl/dictionary/FileBackedDictionary.java
+++ b/extjwnl/src/main/java/net/sf/extjwnl/dictionary/FileBackedDictionary.java
@@ -12,6 +12,7 @@ import org.w3c.dom.Document;
 
 import java.util.Iterator;
 import java.util.NoSuchElementException;
+import java.util.Random;
 
 /**
  * A <code>Dictionary</code> that retrieves objects from the text files
@@ -139,6 +140,17 @@ public class FileBackedDictionary extends AbstractCachingDictionary {
         return word;
     }
 
+    @Override
+    public IndexWord getRandomIndexWord(POS pos,Random random) throws JWNLException {
+        if (!isEditable()) {
+        	fileManager.setRandom(random);
+            CharSequence line = fileManager.getRandomLine(pos, DictionaryFileType.INDEX);
+            return parseAndCacheIndexWord(pos, line);
+        } else {
+            throw new UnsupportedOperationException();
+        }
+    }
+    
     @Override
     public IndexWord getRandomIndexWord(POS pos) throws JWNLException {
         if (!isEditable()) {

--- a/extjwnl/src/main/java/net/sf/extjwnl/dictionary/FileBackedDictionary.java
+++ b/extjwnl/src/main/java/net/sf/extjwnl/dictionary/FileBackedDictionary.java
@@ -12,7 +12,6 @@ import org.w3c.dom.Document;
 
 import java.util.Iterator;
 import java.util.NoSuchElementException;
-import java.util.Random;
 
 /**
  * A <code>Dictionary</code> that retrieves objects from the text files
@@ -140,16 +139,6 @@ public class FileBackedDictionary extends AbstractCachingDictionary {
         return word;
     }
 
-    @Override
-    public IndexWord getRandomIndexWord(POS pos,Random random) throws JWNLException {
-        if (!isEditable()) {
-        	fileManager.setRandom(random);
-            CharSequence line = fileManager.getRandomLine(pos, DictionaryFileType.INDEX);
-            return parseAndCacheIndexWord(pos, line);
-        } else {
-            throw new UnsupportedOperationException();
-        }
-    }
     
     @Override
     public IndexWord getRandomIndexWord(POS pos) throws JWNLException {

--- a/extjwnl/src/main/java/net/sf/extjwnl/dictionary/MapDictionary.java
+++ b/extjwnl/src/main/java/net/sf/extjwnl/dictionary/MapDictionary.java
@@ -141,13 +141,4 @@ public class MapDictionary extends Dictionary {
         return tableMap.get(pos).get(fileType);
     }
 
-	@Override
-	public IndexWord getRandomIndexWord(POS pos, Random random) throws JWNLException {
-		int index = random.nextInt(getTable(pos, DictionaryFileType.INDEX).size());
-        Iterator<IndexWord> itr = getIndexWordIterator(pos);
-        for (int i = 0; i < index && itr.hasNext(); i++) {
-            itr.next();
-        }
-        return itr.hasNext() ? itr.next() : null;
-	}
 }

--- a/extjwnl/src/main/java/net/sf/extjwnl/dictionary/MapDictionary.java
+++ b/extjwnl/src/main/java/net/sf/extjwnl/dictionary/MapDictionary.java
@@ -140,4 +140,14 @@ public class MapDictionary extends Dictionary {
     public Map<Object, DictionaryElement> getTable(POS pos, DictionaryFileType fileType) {
         return tableMap.get(pos).get(fileType);
     }
+
+	@Override
+	public IndexWord getRandomIndexWord(POS pos, Random random) throws JWNLException {
+		int index = random.nextInt(getTable(pos, DictionaryFileType.INDEX).size());
+        Iterator<IndexWord> itr = getIndexWordIterator(pos);
+        for (int i = 0; i < index && itr.hasNext(); i++) {
+            itr.next();
+        }
+        return itr.hasNext() ? itr.next() : null;
+	}
 }

--- a/extjwnl/src/main/java/net/sf/extjwnl/dictionary/file_manager/FileManager.java
+++ b/extjwnl/src/main/java/net/sf/extjwnl/dictionary/file_manager/FileManager.java
@@ -109,7 +109,4 @@ public interface FileManager extends Owned {
      * @throws JWNLException JWNLException
      */
     void edit() throws JWNLException;
-    
-    Random getRandom();
-    void setRandom(Random value);
 }

--- a/extjwnl/src/main/java/net/sf/extjwnl/dictionary/file_manager/FileManager.java
+++ b/extjwnl/src/main/java/net/sf/extjwnl/dictionary/file_manager/FileManager.java
@@ -1,5 +1,7 @@
 package net.sf.extjwnl.dictionary.file_manager;
 
+import java.util.Random;
+
 import net.sf.extjwnl.JWNLException;
 import net.sf.extjwnl.data.POS;
 import net.sf.extjwnl.dictionary.file.DictionaryFileType;
@@ -107,4 +109,7 @@ public interface FileManager extends Owned {
      * @throws JWNLException JWNLException
      */
     void edit() throws JWNLException;
+    
+    Random getRandom();
+    void setRandom(Random value);
 }

--- a/extjwnl/src/main/java/net/sf/extjwnl/dictionary/file_manager/FileManagerImpl.java
+++ b/extjwnl/src/main/java/net/sf/extjwnl/dictionary/file_manager/FileManagerImpl.java
@@ -30,22 +30,6 @@ public class FileManagerImpl implements FileManager {
      */
     public static final String CHECK_PATH_KEY = "check_path";
 
-    /**
-     * Random number generator used by getRandomLine().
-     */
-    private Random rand = null;
-
-    public Random getRandom() {
-    	if(rand==null) {
-    		rand=new Random(new Date().getTime());
-    	}
-		return rand;
-	}
-
-	public void setRandom(Random rand) {
-		this.rand = rand;
-	}
-
 	/**
      * The catalog set.
      */
@@ -240,7 +224,7 @@ public class FileManagerImpl implements FileManager {
         long offset;
         do {
             // casts break long files...
-            offset = start + (long) getRandom().nextInt(range);
+            offset = start + (long) getDictionary().getRandom().nextInt(range);
             // first line is at a disadvantage
             result = file.readLine(file.getNextLineOffset(offset));
         } while (null == result);

--- a/extjwnl/src/main/java/net/sf/extjwnl/dictionary/file_manager/FileManagerImpl.java
+++ b/extjwnl/src/main/java/net/sf/extjwnl/dictionary/file_manager/FileManagerImpl.java
@@ -33,9 +33,20 @@ public class FileManagerImpl implements FileManager {
     /**
      * Random number generator used by getRandomLine().
      */
-    private static final Random rand = new Random(new Date().getTime());
+    private Random rand = null;
 
-    /**
+    public Random getRandom() {
+    	if(rand==null) {
+    		rand=new Random(new Date().getTime());
+    	}
+		return rand;
+	}
+
+	public void setRandom(Random rand) {
+		this.rand = rand;
+	}
+
+	/**
      * The catalog set.
      */
     private final DictionaryCatalogSet<RandomAccessDictionaryFile> files;
@@ -229,7 +240,7 @@ public class FileManagerImpl implements FileManager {
         long offset;
         do {
             // casts break long files...
-            offset = start + (long) rand.nextInt(range);
+            offset = start + (long) getRandom().nextInt(range);
             // first line is at a disadvantage
             result = file.readLine(file.getNextLineOffset(offset));
         } while (null == result);


### PR DESCRIPTION
I'm using this library to create automatic tests. These tests are saved into a file to execute them later, so I need a getRandomIndexWord implementation where a user can pass a random object to run the same test after its creation. I have implemented this method into FileBackedDictionary and MapDictionary. I think that this method is interesting for testing.