### PR TITLE
Add fix and test for getSenseKeyWithAdjClass (which also fixes adjective use count)

### DIFF
--- a/extjwnl/src/main/java/net/sf/extjwnl/data/Word.java
+++ b/extjwnl/src/main/java/net/sf/extjwnl/data/Word.java
@@ -250,7 +250,7 @@ public class Word extends PointerTarget {
                             lemma = lemma + "(" + a.getAdjectivePosition().getKey() + ")";
                         }
                     }
-                    senseKey.append(lemma);
+                    senseKey.append(lemma).append(":");
                     if (word.getLexId() < 10) {
                         senseKey.append("0");
                     }

--- a/extjwnl/src/test/java/net/sf/extjwnl/dictionary/DictionaryReadTester.java
+++ b/extjwnl/src/test/java/net/sf/extjwnl/dictionary/DictionaryReadTester.java
@@ -179,6 +179,16 @@ public class DictionaryReadTester {
     }
 
     @Test
+    public void testRedAdj() throws JWNLException {
+        IndexWord iw = dictionary.getIndexWord(POS.ADJECTIVE, "red");
+        Assert.assertNotNull("IndexWord loaded", iw);
+        Synset synset = iw.getSenses().get(0);
+        Word word = synset.getWords().get(0);
+        Assert.assertEquals("Use count testing", 43, word.getUseCount());
+        Assert.assertEquals("Sense key testing", "red%5:00:01:chromatic:00", word.getSenseKeyWithAdjClass());
+    }
+
+    @Test
     public void testDissilientAdjS() throws JWNLException {
         IndexWord iw = dictionary.getIndexWord(POS.ADJECTIVE, "dissilient");
         Assert.assertNotNull("IndexWord loaded", iw);


### PR DESCRIPTION
This also fixes adjective use count, as demonstrated in the test.  (Without the fix, the use count returns 0, which is the bug I hit.)

For some reason the bug didn't show up for the existing test adjective "bright", only for "red", which is why I had to add a new test case.

I did not apply the other fix mentioned in #24 since it didn't seem to make a difference, although perhaps it is relevant for some other case.
