### PR TITLE
Minor fixes by group 2

### DIFF
--- a/extjwnl/src/main/java/net/sf/extjwnl/data/IndexWord.java
+++ b/extjwnl/src/main/java/net/sf/extjwnl/data/IndexWord.java
@@ -34,7 +34,7 @@ public class IndexWord extends BaseDictionaryElement {
     /**
      * senses are initially stored as offsets, and paged in on demand.
      */
-    private volatile long[] synsetOffsets;
+    private volatile AtomicLongArray[] synsetOffsets;
     /**
      * This is null until getSenses has been called.
      */

--- a/extjwnl/src/main/java/net/sf/extjwnl/princeton/file/PrincetonRandomAccessDictionaryFile.java
+++ b/extjwnl/src/main/java/net/sf/extjwnl/princeton/file/PrincetonRandomAccessDictionaryFile.java
@@ -124,7 +124,7 @@ public class PrincetonRandomAccessDictionaryFile extends AbstractPrincetonRandom
             "  29 Princeton University and LICENSEE agrees to preserve same.  \n";
 
     private static final long PRINCETON_HEADER_LENGTH =
-            PRINCETON_HEADER_HEAD.length() + PRINCETON_HEADER_21.length() + PRINCETON_HEADER_TAIL.length();
+            (long) PRINCETON_HEADER_HEAD.length() + PRINCETON_HEADER_21.length() + PRINCETON_HEADER_TAIL.length();
 
     /**
      * Read-only file permission.
@@ -885,7 +885,7 @@ public class PrincetonRandomAccessDictionaryFile extends AbstractPrincetonRandom
                 if (writePrincetonHeader) {
                     offset = offset + PRINCETON_HEADER_LENGTH;
                 }
-                long safeOffset = Integer.MAX_VALUE - 1;
+                long safeOffset = (long) Integer.MAX_VALUE - 1;
                 StringBuilder sb = new StringBuilder(16 * 1024);
                 for (Synset s : synsets) {
                     sb.delete(0, sb.length());

--- a/extjwnl/src/main/java/net/sf/extjwnl/princeton/file/PrincetonRandomAccessDictionaryFile.java
+++ b/extjwnl/src/main/java/net/sf/extjwnl/princeton/file/PrincetonRandomAccessDictionaryFile.java
@@ -945,7 +945,7 @@ public class PrincetonRandomAccessDictionaryFile extends AbstractPrincetonRandom
                 if (writePrincetonHeader) {
                     offset = offset + PRINCETON_HEADER_LENGTH;
                 }
-                long safeOffset = Integer.MAX_VALUE - 1;
+                long safeOffset = (long) Integer.MAX_VALUE - 1;
                 StringBuilder sb = new StringBuilder(16 * 1024);
                 initBuffers();
                 for (Synset s : synsets) {

--- a/extjwnl/src/main/java/net/sf/extjwnl/princeton/file/PrincetonResourceDictionaryFile.java
+++ b/extjwnl/src/main/java/net/sf/extjwnl/princeton/file/PrincetonResourceDictionaryFile.java
@@ -154,7 +154,7 @@ public class PrincetonResourceDictionaryFile extends AbstractPrincetonRandomAcce
         }
         // we've read the line
 
-        long result = i + 1;
+        long result = (long) i + 1;
         if (result >= buffer.length) {
             result = -1;
         }


### PR DESCRIPTION
In the 'update indexWord' we changed the Long[] to an AtomicLongArray[] because marking an array volatile means that the array itself will always be read fresh and never thread cached, but the items in the array will not be. Similarly, marking a mutable object field volatile means the object reference is volatile but the object itself is not, and other threads may not see updates to the object state. This can be remedied by using the AtomicLongArray class.
Meanwhile the other files the modifications we made were to cast  a long to an element in the mathematical equations.When arithmetic is performed on integers, the result will always be an integer. You can assign that result to a long, double, or float with automatic type conversion, but having started as an int or long, the result will likely not be what you expect.
For instance, if the result of int division is assigned to a floating-point variable, precision will have been lost before the assignment. Likewise, if the result of multiplication is assigned to a long, it may have already overflowed before the assignment.
In either case, the result will not be what was expected. Instead, at least one operand should be cast or promoted to the final type before the operation takes place.