### PR TITLE
The removeAll methods in the IndexWord and Synset classes have been refactored to reduce their cognitive complexity. 

### DIFF
--- a/extjwnl/src/main/java/net/sf/extjwnl/data/IndexWord.java
+++ b/extjwnl/src/main/java/net/sf/extjwnl/data/IndexWord.java
@@ -289,26 +289,30 @@ public class IndexWord extends BaseDictionaryElement {
         @Override
         public boolean removeAll(Collection<?> c) {
             loadAllSynsets();
+            
             if (null != dictionary && dictionary.isEditable()) {
-                Dictionary d = dictionary;
-                List<Synset> copy = new ArrayList<>(this);
-                boolean result = super.removeAll(c);
-                if (result) {
-                    for (Object object : c) {
-                        if (object instanceof Synset) {
-                            Synset synset = (Synset) object;
-                            if (copy.contains(synset)) {
-                                removeWordsFromSynset(synset, lemma);
-                            }
-                        }
-                    }
-                    checkIfWeReEmptyAndRemoveIndexWord(d);
-                }
-                return result;
+                return removeAllFromEditableDictionary(c);
             } else {
                 return super.removeAll(c);
             }
         }
+        
+        private boolean removeAllFromEditableDictionary(Collection<?> c) {
+            Dictionary d = dictionary;
+            List<Synset> copy = new ArrayList<>(this);
+            boolean result = super.removeAll(c);
+            
+            if (result) {
+                for (Object object : c) {
+                    if (object instanceof Synset && copy.contains((Synset) object)) {
+                        removeWordsFromSynset((Synset) object, lemma);
+                    }
+                }
+                checkIfWeReEmptyAndRemoveIndexWord(d);
+            }
+            return result;
+        }
+
 
         @Override
         public boolean retainAll(Collection<?> c) {

--- a/extjwnl/src/main/java/net/sf/extjwnl/data/Synset.java
+++ b/extjwnl/src/main/java/net/sf/extjwnl/data/Synset.java
@@ -260,24 +260,26 @@ public class Synset extends PointerTarget implements DictionaryElement {
 
         @Override
         public boolean removeAll(Collection<?> c) {
-            if (null != dictionary && dictionary.isEditable()) {
+            if (dictionary != null && dictionary.isEditable()) {
                 List<Pointer> copy = new ArrayList<>(this);
                 boolean result = super.removeAll(c);
-                if (dictionary.getManageSymmetricPointers()) {
-                    for (Object object : c) {
-                        if (object instanceof Pointer) {
-                            Pointer pointer = (Pointer) object;
-                            if (copy.contains(pointer)) {
-                                deleteSymmetricPointerFromTarget(pointer);
-                            }
-                        }
-                    }
-                }
+                deleteSymmetricPointersFromTarget(c, copy);
                 return result;
             } else {
                 return super.removeAll(c);
             }
         }
+
+        private void deleteSymmetricPointersFromTarget(Collection<?> c, List<Pointer> copy) {
+            if (dictionary.getManageSymmetricPointers()) {
+                for (Object object : c) {
+                    if (object instanceof Pointer && copy.contains(object)) {
+                        deleteSymmetricPointerFromTarget((Pointer) object);
+                    }
+                }
+            }
+        }
+
 
         @Override
         public boolean retainAll(Collection<?> c) {


### PR DESCRIPTION
In accordance with established guidelines. The refactoring involved reorganizing the method's logic and separating concerns to improve code readability and maintainability.